### PR TITLE
Upgrade node-ignore -> 3.x to solve several known issues.

### DIFF
--- a/pack/recursive.js
+++ b/pack/recursive.js
@@ -28,7 +28,7 @@ function recursiveWalk(basedir, ignoreList) {
   if (ignoreList && ignoreList.length > 0) {
     ignoreRules.push({
       base: basedir,
-      filter: ignore().addPattern(ignoreList).createFilter()
+      filter: ignore().add(ignoreList).createFilter()
     });
   }
 
@@ -76,10 +76,10 @@ function recursiveWalk(basedir, ignoreList) {
 
     if (entries.indexOf(ignoreFilename) >= 0) {
       var entryPath = pathUtils.join(path, ignoreFilename);
-      var rules = fs.readFileSync(entryPath, 'utf8');
+      var rules = fs.readFileSync(entryPath, 'utf8').toString();
       ignoreRules.push({
         base: accessPath,
-        filter: ignore().addPattern(rules.split('\n')).createFilter()
+        filter: ignore().add(rules).createFilter()
       });
     } else {
       ignoreRules.push(null);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "chalk": "^1.1.1",
     "chokidar": "^1.4.2",
     "gunzip-maybe": "^1.2.1",
-    "ignore": "^2.2.19",
+    "ignore": "^3.0.11",
     "minimist": "^1.2.0",
     "pad": "^1.0.0",
     "pretty-bytes": "^2.0.1",


### PR DESCRIPTION
Upgrades [`node-ignore`](https://www.npmjs.com/package/ignore) to the latest `3.0.11` to solve several known issues, including:
- Files should not be re-included if the parent directory is ignored, [#10](https://github.com/kaelzhang/node-ignore/issues/10)
- Works for [windows](https://ci.appveyor.com/project/kaelzhang/node-ignore), finally. [#5](https://github.com/kaelzhang/node-ignore/issues/5)
- Better Handling with trailing whitespaces, wildcards of ignore patterns, according to [gitignore spec](https://git-scm.com/docs/gitignore), and passed all cases described in the spec.

However, it is a pity that there is no existing test cases about `'.runtimeignore'`.
