### PR TITLE
Support multiple directories and custom entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Arguments:
   --list-files  List packaged files only
   --ignore      Add file ignore pattern
   --entry       Set entry point import/require string (defaults to "/")
+  --add-dir     Add a directory into the package (format: <path> or <path>:<package-path>)
 ```
 
 ### Completion

--- a/bin/runtime.js
+++ b/bin/runtime.js
@@ -26,7 +26,9 @@ var packArgs = [
   { name: 'ignore', type: 'string', default: '',
     description: 'Add file ignore pattern' },
   { name: 'entry', type: 'string', default: '/',
-    description: 'Set entry point import/require string (defaults to "/")' }
+    description: 'Set entry point import/require string (defaults to "/")' },
+  { name: 'add-dir', type: 'string', default: '',
+    description: 'Add a directory into the package (format: <path> or <path>:<package-path>)' }
 ];
 
 var runArgs = [

--- a/pack/recursive.js
+++ b/pack/recursive.js
@@ -50,7 +50,7 @@ function recursiveWalk(basedir, ignoreList) {
 
     if (stats.isDirectory()) {
       if (visited[path]) {
-        throw 'file system loop detected';
+        throw 'file system loop detected, path "' + path + '"';
       }
 
       visited[path] = true;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "runtime.js cli",
   "main": "index.js",
   "scripts": {
-    "test": "tape test/index.js && npm run lint",
+    "test": "tape test/index.js test/package-tests.js && npm run lint",
     "lint": "eslint ."
   },
   "bin": {
@@ -40,6 +40,7 @@
     "eslint": "^1.10.3",
     "eslint-config-runtime": "^1.0.0",
     "eslint-plugin-runtime-internal": "^1.0.0",
+    "mock-fs": "^3.11.0",
     "tape": "^4.4.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -60,7 +60,7 @@ test('package ramdisk: multiple runtime js copies', function(t) {
   runtimePack({
     _: [path.resolve(__dirname, 'project-multiple-runtimejs')]
   }, function(err) {
-    t.equal(err, 'directory contains multiple copies of the runtime.js library');
+    t.ok(err.indexOf('found two copies of the runtime.js library') === 0);
     t.end();
   })
 });

--- a/test/package-tests.js
+++ b/test/package-tests.js
@@ -1,0 +1,200 @@
+// Copyright 2016-present runtime.js project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+var test = require('tape');
+var mock = require('mock-fs');
+var fs = require('fs');
+var createPackage = require('../pack');
+var readInitrd = require('../pack/read-initrd');
+
+test('package directory', function(t) {
+  mock({
+    '/home/user/mydir': {
+      'index.js': 'console.log("OK")',
+      'other-file.js': '1 + 2',
+      'node_modules': {
+        'module1': {
+          'index.js': 'module.exports = 1',
+          'package.json': '{"name":"module1"}'
+        },
+        'runtimejs': {
+          'runtimecorelib.json': '{"kernelVersion":1}'
+        }
+      }
+    }
+  });
+
+  t.throws(function() {
+    fs.statSync('/home/user/.initrd');
+  }, /no such file or directory/, 'initrd does not exist');
+
+  createPackage({
+    dir: '/home/user/mydir',
+    dirs: [{
+      dir: '/home/user/mydir',
+      packagePath: ''
+    }],
+    output: '/home/user/.initrd'
+  }, function(err, data) {
+    t.error(err, 'no error');
+    t.doesNotThrow(function() {
+      fs.statSync('/home/user/.initrd');
+    }, 'initrd has been created');
+
+    var initrdData = readInitrd('/home/user/.initrd');
+    t.same(initrdData, { kernelVer: 1 }, 'initrd has valid format')
+
+    t.same(data.bundle, [
+      { path: '/home/user/mydir/index.js',
+        relativePath: 'index.js',
+        name: '/index.js' },
+      { path: '/home/user/mydir/node_modules/module1/index.js',
+        relativePath: 'node_modules/module1/index.js',
+        name: '/node_modules/module1/index.js' },
+      { path: '/home/user/mydir/node_modules/module1/package.json',
+        relativePath: 'node_modules/module1/package.json',
+        name: '/node_modules/module1/package.json' },
+      { path: '/home/user/mydir/node_modules/runtimejs/runtimecorelib.json',
+        relativePath: 'node_modules/runtimejs/runtimecorelib.json',
+        name: '/node_modules/runtimejs/runtimecorelib.json' },
+      { path: '/home/user/mydir/other-file.js',
+        relativePath: 'other-file.js',
+        name: '/other-file.js' }
+    ], 'bundle files');
+
+    t.is(data.indexName, '/node_modules/runtimejs/js/__loader.js');
+    t.is(data.appIndexName, '/');
+
+    mock.restore();
+    t.end();
+  });
+});
+
+test('package multiple directories', function(t) {
+  mock({
+    '/home/user/mydir': {
+      'index.js': 'console.log("OK")',
+      'other-file.js': '1 + 2',
+      'node_modules': {
+        'module1': {
+          'index.js': 'module.exports = 1',
+          'package.json': '{"name":"module1"}'
+        },
+        'runtimejs': {
+          'runtimecorelib.json': '{"kernelVersion":1}'
+        }
+      }
+    },
+    '/other-dir': {
+      'entry.js': 'console.log("other file")',
+      'subdir': {
+        'other-subdir': {
+          'f.js': 'abc()'
+        }
+      }
+    }
+  });
+
+  t.throws(function() {
+    fs.statSync('/home/user/.initrd');
+  }, /no such file or directory/, 'initrd does not exist');
+
+  createPackage({
+    dir: '/home/user/mydir',
+    dirs: [{
+      dir: '/home/user/mydir',
+      packagePath: ''
+    }, {
+      dir: '/other-dir',
+      packagePath: '/abc'
+    }],
+    output: '/home/user/.initrd'
+  }, function(err, data) {
+    t.error(err, 'no error');
+    t.doesNotThrow(function() {
+      fs.statSync('/home/user/.initrd');
+    }, 'initrd has been created');
+
+    var initrdData = readInitrd('/home/user/.initrd');
+    t.same(initrdData, { kernelVer: 1 }, 'initrd has valid format')
+
+    t.same(data.bundle, [
+      { path: '/home/user/mydir/index.js',
+        relativePath: 'index.js',
+        name: '/index.js' },
+      { path: '/home/user/mydir/node_modules/module1/index.js',
+        relativePath: 'node_modules/module1/index.js',
+        name: '/node_modules/module1/index.js' },
+      { path: '/home/user/mydir/node_modules/module1/package.json',
+        relativePath: 'node_modules/module1/package.json',
+        name: '/node_modules/module1/package.json' },
+      { path: '/home/user/mydir/node_modules/runtimejs/runtimecorelib.json',
+        relativePath: 'node_modules/runtimejs/runtimecorelib.json',
+        name: '/node_modules/runtimejs/runtimecorelib.json' },
+      { path: '/home/user/mydir/other-file.js',
+        relativePath: 'other-file.js',
+        name: '/other-file.js' },
+      { path: '/other-dir/entry.js',
+        relativePath: 'entry.js',
+        name: '/abc/entry.js' },
+      { path: '/other-dir/subdir/other-subdir/f.js',
+        relativePath: 'subdir/other-subdir/f.js',
+        name: '/abc/subdir/other-subdir/f.js' }
+    ], 'bundle files');
+
+    t.is(data.indexName, '/node_modules/runtimejs/js/__loader.js');
+    t.is(data.appIndexName, '/');
+
+    mock.restore();
+    t.end();
+  });
+});
+
+test('package and set custom entry points', function(t) {
+  mock({
+    '/home/user/mydir': {
+      'index.js': 'console.log("OK")',
+      'other-file.js': '1 + 2',
+      'node_modules': {
+        'module1': {
+          'index.js': 'module.exports = 1',
+          'package.json': '{"name":"module1"}'
+        },
+        'runtimejs': {
+          'runtimecorelib.json': '{"kernelVersion":1}'
+        }
+      }
+    }
+  });
+
+  createPackage({
+    dir: '/home/user/mydir',
+    dirs: [{
+      dir: '/home/user/mydir',
+      packagePath: ''
+    }],
+    entry: '/z/index.js',
+    systemEntry: '/abc/js.js',
+    output: '/home/user/.initrd'
+  }, function(err, data) {
+    t.error(err, 'no error');
+
+    t.is(data.indexName, '/abc/js.js');
+    t.is(data.appIndexName, '/z/index.js');
+
+    mock.restore();
+    t.end();
+  });
+});

--- a/test/package-tests.js
+++ b/test/package-tests.js
@@ -82,7 +82,7 @@ test('package directory', function(t) {
   });
 });
 
-test('package multiple directories', function(t) {
+test('package two directories', function(t) {
   mock({
     '/home/user/mydir': {
       'index.js': 'console.log("OK")',
@@ -162,6 +162,105 @@ test('package multiple directories', function(t) {
   });
 });
 
+test('package multiple directories', function(t) {
+  mock({
+    '/home/user/mydir': {
+      'index.js': 'console.log("OK")',
+      'other-file.js': '1 + 2',
+      'node_modules': {
+        'module1': {
+          'index.js': 'module.exports = 1',
+          'package.json': '{"name":"module1"}'
+        },
+        'runtimejs': {
+          'runtimecorelib.json': '{"kernelVersion":1}'
+        }
+      }
+    },
+    '/other-dir': {
+      'entry.js': 'console.log("other file")',
+      'subdir': {
+        'other-subdir': {
+          'f.js': 'abc()'
+        }
+      }
+    },
+    '/other-dir2': {
+      'entry.js': 'console.log("other file")',
+      'subdir': {
+        'other-subdir': {
+          'f.js': 'abc()'
+        }
+      }
+    },
+    '/other-dir3': {
+      'entry.js': 'console.log("other file")',
+      'subdir': {
+        'other-subdir': {
+          'f.js': 'abc()'
+        }
+      }
+    }
+  });
+
+  createPackage({
+    dir: '/home/user/mydir',
+    dirs: [{
+      dir: '/home/user/mydir',
+      packagePath: ''
+    }, {
+      dir: '/other-dir',
+      packagePath: '/abc'
+    }, {
+      dir: '/other-dir2',
+      packagePath: '/abc/inner'
+    }, {
+      dir: '/other-dir3',
+      packagePath: '/def'
+    }],
+    output: '/home/user/.initrd'
+  }, function(err, data) {
+    t.error(err, 'no error');
+    t.same(data.bundle, [
+      { path: '/home/user/mydir/index.js',
+        relativePath: 'index.js',
+        name: '/index.js' },
+      { path: '/home/user/mydir/node_modules/module1/index.js',
+        relativePath: 'node_modules/module1/index.js',
+        name: '/node_modules/module1/index.js' },
+      { path: '/home/user/mydir/node_modules/module1/package.json',
+        relativePath: 'node_modules/module1/package.json',
+        name: '/node_modules/module1/package.json' },
+      { path: '/home/user/mydir/node_modules/runtimejs/runtimecorelib.json',
+        relativePath: 'node_modules/runtimejs/runtimecorelib.json',
+        name: '/node_modules/runtimejs/runtimecorelib.json' },
+      { path: '/home/user/mydir/other-file.js',
+        relativePath: 'other-file.js',
+        name: '/other-file.js' },
+      { path: '/other-dir/entry.js',
+        relativePath: 'entry.js',
+        name: '/abc/entry.js' },
+      { path: '/other-dir/subdir/other-subdir/f.js',
+        relativePath: 'subdir/other-subdir/f.js',
+        name: '/abc/subdir/other-subdir/f.js' },
+      { path: '/other-dir2/entry.js',
+        relativePath: 'entry.js',
+        name: '/abc/inner/entry.js' },
+      { path: '/other-dir2/subdir/other-subdir/f.js',
+        relativePath: 'subdir/other-subdir/f.js',
+        name: '/abc/inner/subdir/other-subdir/f.js' },
+      { path: '/other-dir3/entry.js',
+        relativePath: 'entry.js',
+        name: '/def/entry.js' },
+      { path: '/other-dir3/subdir/other-subdir/f.js',
+        relativePath: 'subdir/other-subdir/f.js',
+        name: '/def/subdir/other-subdir/f.js' }
+    ], 'bundle files');
+    mock.restore();
+    t.end();
+  });
+});
+
 test('package and set custom entry points', function(t) {
   mock({
     '/home/user/mydir': {
@@ -194,6 +293,100 @@ test('package and set custom entry points', function(t) {
     t.is(data.indexName, '/abc/js.js');
     t.is(data.appIndexName, '/z/index.js');
 
+    mock.restore();
+    t.end();
+  });
+});
+
+test('fs loop', function(t) {
+  mock({
+    '/home/user/mydir': {
+      'index.js': 'console.log("OK")',
+      'other-file.js': '1 + 2',
+      'node_modules': {
+        'module1': {
+          'index.js': 'module.exports = 1',
+          'package.json': '{"name":"module1"}'
+        },
+        'runtimejs': {
+          'runtimecorelib.json': '{"kernelVersion":1}'
+        },
+        'other': mock.symlink({ path: './runtimejs' })
+      }
+    }
+  });
+
+  createPackage({
+    dir: '/home/user/mydir',
+    dirs: [{
+      dir: '/home/user/mydir',
+      packagePath: ''
+    }],
+    output: '/home/user/.initrd'
+  }, function(err, data) {
+    t.is(err, 'file system loop detected, path "/home/user/mydir/node_modules/runtimejs"');
+    mock.restore();
+    t.end();
+  });
+});
+
+test('directory no runtime.js', function(t) {
+  mock({
+    '/home/user/mydir': {
+      'index.js': 'console.log("OK")',
+      'other-file.js': '1 + 2',
+      'node_modules': {
+        'module1': {
+          'index.js': 'module.exports = 1',
+          'package.json': '{"name":"module1"}'
+        }
+      }
+    }
+  });
+
+  createPackage({
+    dir: '/home/user/mydir',
+    dirs: [{
+      dir: '/home/user/mydir',
+      packagePath: ''
+    }],
+    output: '/home/user/.initrd'
+  }, function(err, data) {
+    t.is(err, 'directory does not contain runtime.js library, please run "npm install runtimejs"');
+    mock.restore();
+    t.end();
+  });
+});
+
+test('directory multiple runtime.js copies', function(t) {
+  mock({
+    '/home/user/mydir': {
+      'index.js': 'console.log("OK")',
+      'other-file.js': '1 + 2',
+      'node_modules': {
+        'module1': {
+          'index.js': 'module.exports = 1',
+          'package.json': '{"name":"module1"}'
+        },
+        'runtimejs': {
+          'runtimecorelib.json': '{"kernelVersion":1}'
+        },
+        'other-runtimejs': {
+          'runtimecorelib.json': '{"kernelVersion":1}'
+        }
+      }
+    }
+  });
+
+  createPackage({
+    dir: '/home/user/mydir',
+    dirs: [{
+      dir: '/home/user/mydir',
+      packagePath: ''
+    }],
+    output: '/home/user/.initrd'
+  }, function(err, data) {
+    t.is(err, 'found two copies of the runtime.js library at "/home/user/mydir/node_modules/other-runtimejs" and "/home/user/mydir/node_modules/runtimejs"');
     mock.restore();
     t.end();
   });


### PR DESCRIPTION
Added 
`--add-dir <dir>:<package-path>` option for importing other dirs into the bundle.
`--entry` for setting main script entry point
`--system-entry` for overwriting runtime.js kernel entry point (will not run runtime.js scripts at all)
