### PR TITLE
Add --drive, mkimg command

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ USAGE: runtime mkimg [<args>] <filename>
 
 Arguments:
   --size        Size of the new image, defaults to 1 gigabyte. See `qemu-img --help` for sizes.
-                Must be >= a gigabyte
+                Must be >= 33792 kb (~33 mb)
   --label       Label of the new image, defaults to "RUNTIMEJS"
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Arguments:
   --add-dir     Add a directory into the package (format: <path> or <path>:<package-path>)
 ```
 
-`mkimg` creates a FAT disk image for use with runtime.js.
+`mkimg` creates a FAT disk image for use with runtime.js. On some systems, you may need to use root/administrator privileges.
 
 ```
 USAGE: runtime mkimg [<args>] <filename>

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Commands:
   pack          Package specified directory into ramdisk bundle
   run           Run runtime.js VM using specified ramdisk bundle
   show          Print VM output or log
+  mkimg         Easily create a disk image for use with runtime.js
   help          Print this usage help
 ```
 
@@ -84,6 +85,21 @@ Arguments:
   --ignore      Add file ignore pattern
   --entry       Set entry point import/require string (defaults to "/")
   --add-dir     Add a directory into the package (format: <path> or <path>:<package-path>)
+```
+
+`mkimg` creates a FAT disk image for use with runtime.js.
+
+```
+USAGE: runtime mkimg [<args>] <filename>
+(Easily create a disk image for use with runtime.js)
+
+  <filename>    The filename for the newly created disk image including the extension,
+                default to "disk.img"
+
+Arguments:
+  --size        Size of the new image, defaults to 1 gigabyte. See `qemu-img --help` for sizes.
+                Must be >= a gigabyte
+  --label       Label of the new image, defaults to "RUNTIMEJS"
 ```
 
 ### Completion

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Arguments:
   --add-dir     Add a directory into the package (format: <path> or <path>:<package-path>)
 ```
 
-`mkimg` creates a FAT disk image for use with runtime.js. On some systems, you may need to use root/administrator privileges.
+`mkimg` creates a FAT disk image for use with runtime.js. On some systems, you may need to use root/administrator privileges. Depends on qemu-img on all platforms, hdiutil and diskutil on macOS (builtin), losetup and mkfs.msdos on Linux (included on most distributions), and diskpart on Windows (bulitin).
 
 ```
 USAGE: runtime mkimg [<args>] <filename>

--- a/bin/runtime.js
+++ b/bin/runtime.js
@@ -93,7 +93,7 @@ var cmds = [{
   name: 'mkimg',
   description: 'Easily create a disk image for use with runtime.js',
   args: mkimgArgs,
-  mainArg: { name: 'filename', description: 'The filename for the newly created disk image including the extension,\ndefault to "disk.img"' }
+  mainArg: { name: 'filename', description: 'The filename for the newly created disk image including the extension,\ndefaults to "disk.img"' }
 }, {
   name: 'help',
   description: 'Print this usage help'

--- a/bin/runtime.js
+++ b/bin/runtime.js
@@ -62,7 +62,7 @@ var runArgs = [
 
 var mkimgArgs = [
   { name: 'size', type: 'string', default: '1G',
-    description: 'Size of the new image, defaults to 1 gigabyte. See `qemu-img --help` for sizes.\nMust be >= a gigabyte' },
+    description: 'Size of the new image, defaults to 1 gigabyte. See `qemu-img --help` for sizes.\nMust be >= 32763 kb (~33 mb)' },
   { name: 'label', type: 'string', default: 'RUNTIMEJS',
     description: 'Label of the new image, defaults to "RUNTIMEJS"' }
 ];

--- a/bin/runtime.js
+++ b/bin/runtime.js
@@ -62,7 +62,7 @@ var runArgs = [
 
 var mkimgArgs = [
   { name: 'size', type: 'string', default: '1G',
-    description: 'Size of the new image, defaults to 1 gigabyte. See `qemu-img --help` for sizes.\nMust be >= 32763 kb (~33 mb)' },
+    description: 'Size of the new image, defaults to 1 gigabyte. See `qemu-img --help` for sizes.\nMust be >= 33792 kb (33 mb)' },
   { name: 'label', type: 'string', default: 'RUNTIMEJS',
     description: 'Label of the new image, defaults to "RUNTIMEJS"' }
 ];

--- a/bin/runtime.js
+++ b/bin/runtime.js
@@ -55,7 +55,16 @@ var runArgs = [
   { name: 'kernel', type: 'string', default: '',
     description: 'Specify custom kernel binary file to use' },
   { name: 'local', type: 'boolean', default: false,
-    description: 'Download the kernel locally (i.e. in the module\'s directory)' }
+    description: 'Download the kernel locally (i.e. in the module\'s directory)' },
+  { name: 'drive', type: 'string', default: '',
+    description: 'A file to attach as a virtio block device' }
+];
+
+var mkimgArgs = [
+  { name: 'size', type: 'string', default: '1G',
+    description: 'Size of the new image, defaults to 1 gigabyte. See `qemu-img --help` for sizes.\nMust be >= a gigabyte' },
+  { name: 'label', type: 'string', default: 'RUNTIMEJS',
+    description: 'Label of the new image, defaults to "RUNTIMEJS"' }
 ];
 
 var cmds = [{
@@ -80,6 +89,11 @@ var cmds = [{
   name: 'show',
   description: 'Print VM output or log',
   mainArg: { name: 'type', description: 'VM output file to print, can be "log" or "netdump",\ndefaults to "log"' }
+}, {
+  name: 'mkimg',
+  description: 'Easily create a disk image for use with runtime.js',
+  args: mkimgArgs,
+  mainArg: { name: 'filename', description: 'The filename for the newly created disk image including the extension,\ndefault to "disk.img"' }
 }, {
   name: 'help',
   description: 'Print this usage help'

--- a/command/runtime-mkimg.js
+++ b/command/runtime-mkimg.js
@@ -18,7 +18,7 @@ var mkimg = require('../mkimg');
 
 module.exports = function(args, cb) {
   if (args._.length === 0) {
-    return cb('no filename specified');
+    args._[0] = 'disk.img';
   }
 
   var filename = String(args._[0]);

--- a/command/runtime-mkimg.js
+++ b/command/runtime-mkimg.js
@@ -16,6 +16,23 @@
 
 var mkimg = require('../mkimg');
 
+const multipliers = {
+  'B': 0.001,           // byte
+  'K': 1,               // kilobyte
+  'M': 1000,            // megabyte
+  'G': 1000000,         // gigabyte
+  'T': 1000000000,      // terabyte
+  'P': 1000000000000,   // petabyte
+  'E': 1000000000000000 // exabyte
+};
+const letterRegex = /[A-Za-z]/;
+
+function toKB(size) {
+  var suffix = size.substr(size.length - 1);
+  if (!letterRegex.test(suffix)) suffix = 'B';
+  return parseInt(size, 10) * multipliers[suffix.toUpperCase()];
+}
+
 module.exports = function(args, cb) {
   if (args._.length === 0) {
     args._[0] = 'disk.img';
@@ -24,9 +41,9 @@ module.exports = function(args, cb) {
   var filename = String(args._[0]);
 
   var size = String(args.size);
-  var suffix = size.substr(size.length - 1);
-  if (suffix !== 'G' && suffix !== 'T' && suffix !== 'P' && suffix !== 'E') {
-    return cb('valid sizes are only >= gigabytes (G, T, etc.). see `qemu-img --help` for more sizes');
+  var sizeInKb = toKB(size);
+  if (sizeInKb < 33792) {
+    return cb('invalid size for FAT32. minimum limit of 33792 kb (~33 mb)');
   }
 
   var label = String(args.label).toUpperCase(); // valid names for FAT volumes are upper case

--- a/command/runtime-mkimg.js
+++ b/command/runtime-mkimg.js
@@ -1,0 +1,39 @@
+// Copyright 2016-present runtime.js project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+var mkimg = require('../mkimg');
+
+module.exports = function(args, cb) {
+  if (args._.length === 0) {
+    return cb('no filename specified');
+  }
+
+  var filename = String(args._[0]);
+
+  var size = String(args.size);
+  var suffix = size.substr(size.length - 1);
+  if (suffix !== 'G' && suffix !== 'T' && suffix !== 'P' && suffix !== 'E') {
+    return cb('valid sizes are only >= gigabytes (G, T, etc.). see `qemu-img --help` for more sizes');
+  }
+
+  var label = String(args.label).toUpperCase(); // valid names for FAT volumes are upper case
+
+  mkimg({
+    size: size,
+    filename: filename,
+    label: label
+  }, cb);
+};

--- a/command/runtime-run.js
+++ b/command/runtime-run.js
@@ -57,7 +57,7 @@ module.exports = function(args, cb) {
   if (typeof args.drive === 'string') {
     drives = [args.drive];
   }
-  if (args.drive instanceof Array) {
+  if (Array.isArray(args.drive)) {
     drives = args.drive;
   }
 
@@ -81,7 +81,7 @@ module.exports = function(args, cb) {
       virtioRng: qemuVirtioRng,
       nographic: qemuNographic,
       ports: extraPorts.filter(Boolean),
-      drives: drives
+      drives: drives.filter(Boolean)
     }, cb);
   });
 };

--- a/command/runtime-run.js
+++ b/command/runtime-run.js
@@ -53,6 +53,14 @@ module.exports = function(args, cb) {
   var dryRun = !!args['dry-run'];
   var verbose = !!args.verbose;
 
+  var drives = [];
+  if (typeof args.drive === 'string') {
+    drives = [args.drive];
+  }
+  if (args.drive instanceof Array) {
+    drives = args.drive;
+  }
+
   getRuntime(fileData.kernelVer, kernelFile, !!args.local, function(err, runtimeFile) {
     if (err) {
       return cb(err)
@@ -72,7 +80,8 @@ module.exports = function(args, cb) {
       verbose: verbose,
       virtioRng: qemuVirtioRng,
       nographic: qemuNographic,
-      ports: extraPorts.filter(Boolean)
+      ports: extraPorts.filter(Boolean),
+      drives: drives
     }, cb);
   });
 };

--- a/mkimg/index.js
+++ b/mkimg/index.js
@@ -1,0 +1,39 @@
+// Copyright 2016-present runtime.js project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+var chalk = require('chalk');
+var shell = require('shelljs');
+var exec = require('../run/shell-exec');
+
+module.exports = function(opts, cb) {
+  var helper;
+  if (process.platform === 'darwin') {
+    helper = require('./macos');
+  } else if (process.platform === 'win32') {
+    helper = require('./windows');
+  } else if (process.platform === 'linux') {
+    helper = require('./linux');
+  } else {
+    return cb('unknown/unsupported platform');
+  }
+
+  shell.echo(chalk.green(' --- creating image --- '));
+
+  exec('qemu-img create ' + opts.filename + ' ' + opts.size, function(code, output) {
+    shell.echo(chalk.green(' --- formatting image --- '));
+    helper(opts, cb);
+  });
+};

--- a/mkimg/index.js
+++ b/mkimg/index.js
@@ -17,6 +17,7 @@
 var chalk = require('chalk');
 var shell = require('shelljs');
 var exec = require('../run/shell-exec');
+var testCmd = require('./testCmd');
 
 module.exports = function(opts, cb) {
   var helper;
@@ -29,6 +30,8 @@ module.exports = function(opts, cb) {
   } else {
     return cb('unknown/unsupported platform');
   }
+
+  testCmd('qemu-img', false);
 
   shell.echo(chalk.yellow('warning: it may appear that the process has frozen when creating large disk images'));
   shell.echo(chalk.green(' --- creating image --- '));

--- a/mkimg/index.js
+++ b/mkimg/index.js
@@ -30,6 +30,7 @@ module.exports = function(opts, cb) {
     return cb('unknown/unsupported platform');
   }
 
+  shell.echo(chalk.yellow('warning: it may appear that the process has frozen when creating large disk images'));
   shell.echo(chalk.green(' --- creating image --- '));
 
   exec('qemu-img create ' + opts.filename + ' ' + opts.size, function(code, output) {

--- a/mkimg/linux.js
+++ b/mkimg/linux.js
@@ -1,0 +1,21 @@
+// Copyright 2016-present runtime.js project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+var exec = require('../run/shell-exec');
+
+module.exports = function(opts, cb) {
+  cb();
+};

--- a/mkimg/linux.js
+++ b/mkimg/linux.js
@@ -17,5 +17,12 @@
 var exec = require('../run/shell-exec');
 
 module.exports = function(opts, cb) {
-  cb();
+  exec('losetup -f ' + opts.filename, function(code, output) {
+    var mountpoint = output.trim();
+    exec('mkfs.msdos -F 32 -n "' + opts.label + '" ' + mountpoint, function(code, output) {
+      exec('losetup -d ' + mountpoint, function(code, output) {
+        cb();
+      });
+    });
+  });
 };

--- a/mkimg/linux.js
+++ b/mkimg/linux.js
@@ -17,11 +17,13 @@
 var exec = require('../run/shell-exec');
 
 module.exports = function(opts, cb) {
-  exec('losetup -f ' + opts.filename, function(code, output) {
+  exec('losetup -f', function(code, output) {
     var mountpoint = output.trim();
-    exec('mkfs.msdos -F 32 -n "' + opts.label + '" ' + mountpoint, function(code, output) {
-      exec('losetup -d ' + mountpoint, function(code, output) {
-        cb();
+    exec('losetup ' + mountpoint + ' ' + opts.filename, function(code, output) {
+      exec('mkfs.msdos -F 32 -n "' + opts.label + '" ' + mountpoint, function(code, output) {
+        exec('losetup -d ' + mountpoint, function(code, output) {
+          cb();
+        });
       });
     });
   });

--- a/mkimg/macos.js
+++ b/mkimg/macos.js
@@ -15,8 +15,12 @@
 'use strict';
 
 var exec = require('../run/shell-exec');
+var testCmd = require('./testCmd');
 
 module.exports = function(opts, cb) {
+  testCmd('hdiutil', true);
+  testCmd('diskutil', true);
+
   exec('hdiutil attach ' + opts.filename + ' -nomount', function(code, output) {
     var mountpoint = output.trim();
     exec('diskutil eraseVolume fat32 "' + opts.label + '" ' + mountpoint, function(code, output) {

--- a/mkimg/macos.js
+++ b/mkimg/macos.js
@@ -1,0 +1,28 @@
+// Copyright 2016-present runtime.js project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+var exec = require('../run/shell-exec');
+
+module.exports = function(opts, cb) {
+  exec('hdiutil attach ' + opts.filename + ' -nomount', function(code, output) {
+    var mountpoint = output.trim();
+    exec('diskutil eraseVolume fat32 "' + opts.label + '" ' + mountpoint, function(code, output) {
+      exec('hdiutil detach ' + mountpoint, function(code, output) {
+        cb();
+      });
+    });
+  });
+};

--- a/mkimg/testCmd.js
+++ b/mkimg/testCmd.js
@@ -14,21 +14,12 @@
 
 'use strict';
 
-var exec = require('../run/shell-exec');
-var testCmd = require('./testCmd');
+var shell = require('shelljs');
+var chalk = require('chalk');
 
-module.exports = function(opts, cb) {
-  testCmd('losetup', true);
-  testCmd('mkfs.msdos', false);
-
-  exec('losetup -f', function(code, output) {
-    var mountpoint = output.trim();
-    exec('losetup ' + mountpoint + ' ' + opts.filename, function(code, output) {
-      exec('mkfs.msdos -F 32 -n "' + opts.label + '" ' + mountpoint, function(code, output) {
-        exec('losetup -d ' + mountpoint, function(code, output) {
-          cb();
-        });
-      });
-    });
-  });
+module.exports = function(cmd, isBuiltin) {
+  if (!shell.which(cmd)) {
+    shell.echo(chalk.red('error: ' + cmd + ((isBuiltin) ? ' cannot be found' : ' is not installed (or cannot be found)')));
+    return shell.exit(1);
+  }
 };

--- a/mkimg/windows.js
+++ b/mkimg/windows.js
@@ -1,0 +1,21 @@
+// Copyright 2016-present runtime.js project authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+var exec = require('../run/shell-exec');
+
+module.exports = function(opts, cb) {
+  cb();
+};

--- a/mkimg/windows.js
+++ b/mkimg/windows.js
@@ -17,19 +17,20 @@
 var exec = require('../run/shell-exec');
 var path = require('path');
 var os = require('os');
+var fs = require('fs');
 
 // Some code from generateGUID used from http://stackoverflow.com/a/2117523/6620880
 // Courtesy of broofa on StackOverflow (http://stackoverflow.com/users/109538)
 function generateGUID() {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-    var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
+    var r = Math.random() * 16 | 0, v = c === 'x' ? r : (r & 0x3 | 0x8);
     return v.toString(16);
   });
 }
 
 module.exports = function(opts, cb) {
   var guid = generateGUID();
-  var vhdName = os.tmpdir() + path.sep + 'runtime-tmp-vhd-' guid + '.vhd';
+  var vhdName = os.tmpdir() + path.sep + 'runtime-tmp-vhd-' + guid + '.vhd';
   exec('qemu-img convert -f raw -O vpc ' + opts.filename + ' ' + vhdName, function(code, output) {
     var tmpScriptName = os.tmpdir() + path.sep + 'runtime-diskpart-' + guid + '.txt';
     fs.writeFile(tmpScriptName, [

--- a/mkimg/windows.js
+++ b/mkimg/windows.js
@@ -15,6 +15,7 @@
 'use strict';
 
 var exec = require('../run/shell-exec');
+var testCmd = require('./testCmd');
 var path = require('path');
 var os = require('os');
 var fs = require('fs');
@@ -46,6 +47,8 @@ function toMB(size) {
 }
 
 module.exports = function(opts, cb) {
+  testCmd('diskpart', true);
+
   var guid = generateGUID();
   var vhdName = os.tmpdir() + path.sep + 'runtime-tmp-vhd-' + guid + '.vhd';
   var tmpScriptName = os.tmpdir() + path.sep + 'runtime-diskpart-' + guid + '.txt';

--- a/mkimg/windows.js
+++ b/mkimg/windows.js
@@ -37,7 +37,7 @@ const multipliers = {
 
 function toMB(size) {
   var suffix = size.substr(size.length - 1);
-  return parseInt(size) * multipliers[suffix];
+  return parseInt(size, 10) * multipliers[suffix];
 }
 
 module.exports = function(opts, cb) {

--- a/mkimg/windows.js
+++ b/mkimg/windows.js
@@ -29,15 +29,20 @@ function generateGUID() {
 }
 
 const multipliers = {
-  'G': 1000,
-  'T': 1000000,
-  'P': 1000000000,
-  'E': 1000000000000
+  'B': 0.000001,     // byte
+  'K': 0.001,        // kilobyte
+  'M': 1,            // megabyte
+  'G': 1000,         // gigabyte
+  'T': 1000000,      // terabyte
+  'P': 1000000000,   // petabyte
+  'E': 1000000000000 // exabyte
 };
+const letterRegex = /[A-Za-z]/;
 
 function toMB(size) {
   var suffix = size.substr(size.length - 1);
-  return parseInt(size, 10) * multipliers[suffix];
+  if (!letterRegex.test(suffix)) suffix = 'B';
+  return parseInt(size, 10) * multipliers[suffix.toUpperCase()];
 }
 
 module.exports = function(opts, cb) {

--- a/run/qemu.js
+++ b/run/qemu.js
@@ -107,6 +107,12 @@ function getQemuArgs(opts) {
     a.push('-append "' + opts.append + '"');
   }
 
+  if (opts.drives.length > 0) {
+    for (var i = 0; i < opts.drives.length; i++) {
+      a.push('-drive file="' + opts.drives[i] + '",if=virtio,media=disk,format=raw');
+    }
+  }
+
   return a;
 }
 

--- a/run/qemu.js
+++ b/run/qemu.js
@@ -109,7 +109,9 @@ function getQemuArgs(opts) {
 
   if (opts.drives.length > 0) {
     for (var i = 0; i < opts.drives.length; i++) {
-      a.push('-drive file="' + opts.drives[i] + '",if=virtio,media=disk,format=raw');
+      // not wrapping the filename in quotes because the Windows command prompt
+      // doesn't remove the quotes when passing it to QEMU and causes an "invalid argument" error
+      a.push('-drive file=' + opts.drives[i] + ',if=virtio,media=disk,format=raw');
     }
   }
 


### PR DESCRIPTION
Adds a `--drive` option for `run`, `start`, and `watch` to allow attaching disk image files as virtio-blk devices.

Also adds an `mkimg` command for creating FAT32 images to use them with runtime.js. Depends  on `qemu-img` on all platforms, `hdiutil` and `diskutil` on macOS (builtin), `losetup` and `mkfs.msdos` on Linux (included on most distributions), and `diskpart` on Windows (bulitin). Probably should also add code to check whether the commands are present.

Tested on:
- [x] macOS (Sierra 10.12)
- [x] Windows (>= 7)
- [x] Linux (>= Ubuntu 14)
