### PR TITLE
added pack --output flag

### DIFF
--- a/bin/runtime.js
+++ b/bin/runtime.js
@@ -30,7 +30,7 @@ var packArgs = [
   { name: 'add-dir', type: 'string', default: '',
     description: 'Add a directory into the package (format: <path> or <path>:<package-path>)' },
   { name: 'output', type: 'string', default: '',
-    description: 'allow custom naming and location of the .initrd image\n(format: --output <initrd name> or --output <directory/initrd name>'}
+    description: 'Initrd output file (defaults to .initrd)\nformat: --output <initrd name> or --output <directory/initrd name>'}
 ];
 
 var runArgs = [

--- a/bin/runtime.js
+++ b/bin/runtime.js
@@ -28,7 +28,9 @@ var packArgs = [
   { name: 'entry', type: 'string', default: '/',
     description: 'Set entry point import/require string (defaults to "/")' },
   { name: 'add-dir', type: 'string', default: '',
-    description: 'Add a directory into the package (format: <path> or <path>:<package-path>)' }
+    description: 'Add a directory into the package (format: <path> or <path>:<package-path>)' },
+  { name: 'output', type: 'string', default: '',
+    description: 'allow custom naming and location of the .initrd image\n(format: --output <initrd name> or --output <directory/initrd name>'}
 ];
 
 var runArgs = [
@@ -59,9 +61,7 @@ var runArgs = [
   { name: 'local', type: 'boolean', default: false,
     description: 'Download the kernel locally (i.e. in the module\'s directory)' },
   { name: 'drive', type: 'string', default: '',
-    description: 'A file to attach as a virtio block device' },
-  { name: 'output', type: 'string', default: '',
-      description: 'allow custom naming and location of the .initrd image (format: --output <initrd name> or --output <directory/initrd name>'}
+    description: 'A file to attach as a virtio block device' }
 ];
 
 var mkimgArgs = [

--- a/bin/runtime.js
+++ b/bin/runtime.js
@@ -59,7 +59,9 @@ var runArgs = [
   { name: 'local', type: 'boolean', default: false,
     description: 'Download the kernel locally (i.e. in the module\'s directory)' },
   { name: 'drive', type: 'string', default: '',
-    description: 'A file to attach as a virtio block device' }
+    description: 'A file to attach as a virtio block device' },
+  { name: 'output', type: 'string', default: '',
+      description: 'allow custom naming and location of the .initrd image (format: --output <initrd name> or --output <directory/initrd name>'}
 ];
 
 var mkimgArgs = [

--- a/command/runtime-pack.js
+++ b/command/runtime-pack.js
@@ -27,8 +27,8 @@ module.exports = function(args, cb) {
   }
 
   var output = '';
-  if (args['output']) {
-    output = args['output'];
+  if (args.output) {
+    output = args.output;
   }
 
   var addDirs = [];

--- a/command/runtime-pack.js
+++ b/command/runtime-pack.js
@@ -28,7 +28,7 @@ module.exports = function(args, cb) {
 
   var output = '';
   if (args['output']) {
-    ouput = args['output'];
+    output = args['output'];
   }
 
   var addDirs = [];

--- a/command/runtime-pack.js
+++ b/command/runtime-pack.js
@@ -26,6 +26,11 @@ module.exports = function(args, cb) {
     return cb('invalid directory specified');
   }
 
+  var output = '';
+  if (args['output']) {
+    ouput = args['output'];
+  }
+
   var addDirs = [];
   if (args['add-dir']) {
     addDirs = Array.isArray(args['add-dir']) ? args['add-dir'] : [args['add-dir']];
@@ -81,6 +86,7 @@ module.exports = function(args, cb) {
     ignore: ignore,
     verbose: verbose,
     entry: args.entry,
-    systemEntry: args['system-entry']
+    systemEntry: args['system-entry'],
+    output: output
   }, cb);
 };

--- a/command/runtime-run.js
+++ b/command/runtime-run.js
@@ -32,7 +32,7 @@ module.exports = function(args, cb) {
   if (!fileData) {
     return cb('ramdisk bundle read error');
   }
-
+  
   var qemuNet = args.net;
 
   var extraPorts = [];


### PR DESCRIPTION
Added the ability to choose name and location of the default .initrd image by enabling the `--output`  flag. Example usage: 
`runtime pack --output new.initrd dir-to-pack` 
or 
`runtime pack --output ~/home/runtime/new.initrd dir-to-pack`